### PR TITLE
Add GET endpoint for signup-token

### DIFF
--- a/backend/db/signup_token.go
+++ b/backend/db/signup_token.go
@@ -17,7 +17,7 @@ type DBSignupTokenStore struct {
 
 func (s DBSignupTokenStore) GetSignupToken(TokStr string, ctx context.Context) (*types.SignupToken, error) {
 	var result types.SignupToken
-	err := s.Col.FindOne(ctx, bson.M{"tokStr": TokStr}).Decode(&result)
+	err := s.Col.FindOne(ctx, bson.M{"tok_str": TokStr}).Decode(&result)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			return nil, types.ErrSignupTokenNotExist

--- a/backend/main.go
+++ b/backend/main.go
@@ -141,6 +141,7 @@ func main() {
 		types.RolePilot:    {},
 	}), auth.Logout(sessionStore))
 	r.POST("/signup-tokens", auth.UserAuthMiddleware(sessionStore, map[types.Role]struct{}{types.RoleSysAdmin: {}}), auth.CreateSignupToken(signupTokenStore))
+	r.GET("/signup-tokens/:id", auth.GetSignupToken(signupTokenStore))
 	r.POST("/signup", auth.Signup(userStore, signupTokenStore, sessionStore))
 	r.GET("/whoami", auth.UserAuthMiddleware(sessionStore, map[types.Role]struct{}{
 		types.RoleSysAdmin: {},

--- a/backend/types/tokens.go
+++ b/backend/types/tokens.go
@@ -10,13 +10,13 @@ import (
 
 type SignupToken struct {
 	ID        primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
-	TokStr    string             `bson:"tok_str" json:"tok_str"`
-	Email     string             `bson:"email" json:"email"`
-	Phone     string             `bson:"phone" json:"phone"`
-	Role      Role               `bson:"role" json:"role"`
-	PilotInfo *PilotInfo         `bson:"pilot_info" json:"pilot_info"`
-	CreatedAt time.Time          `bson:"created_at" json:"created_at"`
-	Expires   time.Time          `bson:"expires" json:"expires"`
+	TokStr    string             `bson:"tok_str" json:"tok_str,omitempty"`
+	Email     string             `bson:"email" json:"email,omitempty"`
+	Phone     string             `bson:"phone" json:"phone,omitempty"`
+	Role      Role               `bson:"role" json:"role,omitempty"`
+	PilotInfo *PilotInfo         `bson:"pilot_info" json:"pilot_info,omitempty"`
+	CreatedAt time.Time          `bson:"created_at" json:"created_at,omitzero"`
+	Expires   time.Time          `bson:"expires_at" json:"expires,omitzero"`
 }
 
 var ErrSignupTokenNotExist = errors.New("Signup token does not exist")


### PR DESCRIPTION
For user comfort, it would be best if all the information available from the user invitation step is already available during registration. To do so, I've implemented a GET endpoint that you can send a token string to get back the server-side contents for that account creation token

The result of this API call can (and should) be used to either minimize the amount of registration fields, or auto-fill those of them that were already available